### PR TITLE
Add top-level 'types' property in package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,6 +4,7 @@
 	"description": "Astro integration to generate page screenshots to show as Open Graph images",
 	"license": "ISC",
 	"repository": "vadimdemedes/astro-selfie",
+	"types": "./dist/index.d.ts",
 	"author": {
 		"name": "Vadim Demedes",
 		"email": "vadimdemedes@hey.com",


### PR DESCRIPTION
Hey!
I had some issues with types when using astro-selfie, after some research I learned that package.json should contain a top-level `types` property in order for types to work([link](https://www.typescriptlang.org/docs/handbook/declaration-files/publishing.html)). 
Before:
![before](https://github.com/vadimdemedes/astro-selfie/assets/62846961/29f01780-3805-49a7-996b-ca19e1949a50)

After:
![after](https://github.com/vadimdemedes/astro-selfie/assets/62846961/656e1653-66b8-43ec-b44d-d3988b409f82)

`package.json`
```diff
{
        "name": "astro-selfie",
        ...
+	"types": "./dist/index.d.ts",
	"repository": "vadimdemedes/astro-selfie",
        ...
}
```